### PR TITLE
feat: add GET /stats endpoint

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -2,11 +2,18 @@ use crate::api::models::{
     AddMessageRequest, DeleteMessagesRequest, GetMessagesRequest, RetryMessagesRequest,
 };
 use crate::services::MessageService;
-use crate::types::Message;
+use crate::types::{Message, QueueStats};
 use axum::extract::State;
 use axum::Json;
 use skyak_axum_core::errors::ApiError;
 use skyak_axum_core::https::{error, success, ApiResponse};
+
+pub async fn stats(State(service): State<MessageService>) -> ApiResponse<QueueStats> {
+    match service.stats().await {
+        Ok(stats) => success(stats),
+        Err(message) => error(ApiError::BadRequest(Some(message))),
+    }
+}
 
 pub async fn add_message(
     State(service): State<MessageService>,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9,6 +9,7 @@ mod models;
 pub fn create_api(service: MessageService) -> Router {
     Router::new()
         .route("/hello", get(health::check))
+        .route("/stats", get(handlers::stats))
         .route("/add", post(handlers::add_message))
         .route("/get", post(handlers::get_messages))
         .route("/delete", post(handlers::delete_messages))

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,6 +1,6 @@
 use crate::config;
 use crate::storage::traits::Storage;
-use crate::types::Message;
+use crate::types::{Message, QueueStats};
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -27,6 +27,10 @@ impl MessageService {
 
     pub async fn get(&self, count: usize) -> Result<Vec<Message>, String> {
         self.store.get(count).await
+    }
+
+    pub async fn stats(&self) -> Result<QueueStats, String> {
+        self.store.stats().await
     }
 
     pub async fn delete(&self, ids: Vec<String>) -> Result<(), String> {

--- a/src/storage/memory/base.rs
+++ b/src/storage/memory/base.rs
@@ -1,4 +1,4 @@
-use crate::types::{Message, MessageState};
+use crate::types::{Message, MessageState, QueueStats};
 use std::collections::HashMap;
 
 pub struct BaseMemoryStorage {
@@ -30,6 +30,13 @@ impl BaseMemoryStorage {
         }
 
         Ok(messages)
+    }
+
+    pub(crate) async fn stats(&self) -> Result<QueueStats, String> {
+        Ok(QueueStats {
+            ready: self.queue.len(),
+            processing: self.processing.len(),
+        })
     }
 
     pub(crate) async fn delete(&mut self, ids: Vec<String>) -> Result<(), String> {
@@ -177,5 +184,20 @@ mod tests {
 
         assert_eq!(storage.queue.len(), 2);
         assert_eq!(storage.processing.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_base_memory_storage_stats() {
+        let mut storage = setup_storage();
+
+        let stats = storage.stats().await.unwrap();
+        assert_eq!(stats.ready, 3);
+        assert_eq!(stats.processing, 0);
+
+        storage.get(2).await.unwrap();
+
+        let stats = storage.stats().await.unwrap();
+        assert_eq!(stats.ready, 1);
+        assert_eq!(stats.processing, 2);
     }
 }

--- a/src/storage/memory/mod.rs
+++ b/src/storage/memory/mod.rs
@@ -1,5 +1,5 @@
 use crate::storage::traits::Storage;
-use crate::types::Message;
+use crate::types::{Message, QueueStats};
 use async_trait::async_trait;
 use base::BaseMemoryStorage;
 use std::sync::Arc;
@@ -35,6 +35,11 @@ impl Storage for MemoryStorage {
     async fn get(&self, count: usize) -> Result<Vec<Message>, String> {
         let mut storage = self.inner.lock().await;
         storage.get(count).await
+    }
+
+    async fn stats(&self) -> Result<QueueStats, String> {
+        let storage = self.inner.lock().await;
+        storage.stats().await
     }
 
     async fn delete(&self, ids: Vec<String>) -> Result<(), String> {

--- a/src/storage/traits.rs
+++ b/src/storage/traits.rs
@@ -1,4 +1,4 @@
-use crate::types::Message;
+use crate::types::{Message, QueueStats};
 use async_trait::async_trait;
 
 #[async_trait]
@@ -8,4 +8,5 @@ pub trait Storage: Send + Sync {
     async fn delete(&self, ids: Vec<String>) -> Result<(), String>;
     async fn purge(&self) -> Result<(), String>;
     async fn retry(&self, ids: Vec<String>) -> Result<(), String>;
+    async fn stats(&self) -> Result<QueueStats, String>;
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -29,6 +29,15 @@ pub struct Message {
     pub retry_count: i32,
 }
 
+/// Queue statistics showing the number of messages in each state
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueueStats {
+    /// Number of messages available for processing
+    pub ready: usize,
+    /// Number of messages currently being processed
+    pub processing: usize,
+}
+
 impl Message {
     /// Creates a new message with the given body.
     /// Initializes with:

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,2 +1,3 @@
 pub mod healthcheck;
 pub mod messages;
+pub mod stats;

--- a/tests/integration/stats/mod.rs
+++ b/tests/integration/stats/mod.rs
@@ -1,0 +1,43 @@
+use crate::common::{create_get_request, create_post_request, send_request, setup_test_app};
+use http::StatusCode;
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn test_stats_empty_queue() {
+    let app = setup_test_app();
+
+    let response = app.oneshot(create_get_request("/stats")).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+
+    assert_eq!(body_json["ready"], json!(0));
+    assert_eq!(body_json["processing"], json!(0));
+}
+
+#[tokio::test]
+async fn test_stats_with_ready_and_processing_messages() {
+    let mut app = setup_test_app().into_service();
+
+    for i in 1..=5 {
+        let request = create_post_request("/add", json!({"body": format!("message {}", i)}));
+        send_request(&mut app, request).await;
+    }
+
+    let request = create_post_request("/get", json!({"count": 2}));
+    send_request(&mut app, request).await;
+
+    let response = send_request(&mut app, create_get_request("/stats")).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_json = serde_json::from_slice::<serde_json::Value>(&body).unwrap();
+
+    assert_eq!(body_json["ready"], json!(3));
+    assert_eq!(body_json["processing"], json!(2));
+}


### PR DESCRIPTION
Add a `GET /stats` endpoint that returns the number of messages in each state:

`{"ready": 5, "processing": 2}`

This allows monitoring queue health without consuming messages.

Changes:
- Add QueueStats type
- Add stats() to storage trait and memory implementation
- Add GET /stats handler and route
- Add unit and integration tests